### PR TITLE
update: Reject가 없고 승인된 PR만 자동으로 Merge

### DIFF
--- a/.github/workflows/scheduled-merge.yml
+++ b/.github/workflows/scheduled-merge.yml
@@ -31,7 +31,9 @@ jobs:
               });
 
               const approved = reviews.some(r => r.state === "APPROVED");
-              if (!approved) continue;
+              const changesRequested = reviews.some(r => r.state === "CHANGES_REQUESTED");
+              
+              if (!approved || changesRequested) continue;
 
               await github.rest.pulls.merge({
                 owner: context.repo.owner,


### PR DESCRIPTION
### 상세
- 변경사항 요청이 있을 경우 승인되더라도 자동으로 merge 되지 않게 처리
- 승인되었고, 변경사항 요청이 없는 PR만 자동으로 merge